### PR TITLE
Add authorship attribution on post pages

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,24 @@
+dave_kroondyk:
+  github: davekaro
+  name: Dave Kroondyk
+  twitter: davekaro
+eric_kelly:
+  github: HeroicEric
+  name: Eric Kelly
+  twitter: HeroicEric
+faizaan_shamsi:
+  github: faizaanshamsi
+  name: Faizaan Shamsi
+  twitter: faizaanshamsi
+jodi_detch:
+  github: jdetch
+  name: Jodi Detch
+  twitter: greenfieldhq
+mike_munroe:
+  github: mikepmunroe
+  name: Mike Munroe
+  twitter: mikepmunroe
+ryan_tremaine:
+  github: rtremaine
+  name: Ryan Tremaine
+  twitter: ryantremaine

--- a/_includes/themes/twitter-3/post.html
+++ b/_includes/themes/twitter-3/post.html
@@ -1,12 +1,25 @@
+{% assign author = site.data.authors[page.author] %}
+
 <div class="page-header">
   <h1>{{ page.title }} {% if page.tagline %}<small>{{page.tagline}}</small>{% endif %}</h1>
 </div>
 
 <div class="row-fluid post-full">
   <div class="span12">
-    <div class="date">
-      <span>{{ page.date | date_to_long_string }}</span>
-    </div>
+    <ul class="list-inline">
+      {% if author %}
+        <li>
+          <a href="https://twitter.com/{{ author.twitter }}" target="_blank">
+            <span class="label label-success">{{ author.name }}</span>
+          </a>
+        </li>
+      {% endif %}
+
+      <li>
+        <div class="date">{{ page.date | date_to_long_string }}</div>
+      </li>
+    </ul>
+
     <div class="content">
       {{ content }}
     </div>

--- a/_posts/2014-04-12-fixture-assertion-with-ember-cli.md
+++ b/_posts/2014-04-12-fixture-assertion-with-ember-cli.md
@@ -5,7 +5,7 @@ tagline: "Fixtures Assertion in Ember-CLI"
 tags : [ember, ember-cli]
 title: "Assertion Failed: Unable to find fixtures for model using Ember-CLI"
 description: How to fix assertion on fixtures set up within an Ember-CLI project.
-author: Mike Munroe
+author: mike_munroe
 ---
 {% include JB/setup %}
 

--- a/_posts/2014-04-27-building-an-app-with-ember-cli-part1.md
+++ b/_posts/2014-04-27-building-an-app-with-ember-cli-part1.md
@@ -5,7 +5,7 @@ tagline: ""
 tags : [ember, ember-cli]
 title: "Building an Application with Ember-CLI Part 1"
 description: First part of a series on building an app with Ember-CLI.
-author: Mike Munroe
+author: mike_munroe
 ---
 {% include JB/setup %}
 **UPDATE** (05/16/2014): Bryan Cardarella from DockYard is working on a similar tutorial and he has gone a bit more in depth than I have. Rather than regurgitate similar coverage on our blog, head over and check out Bryan's [coverage of the same topic](http://reefpoints.dockyard.com/2014/05/07/building-an-ember-app-with-rails-part-1.html).

--- a/_posts/2014-06-06-adding-bootstrap-to-ember-cli.md
+++ b/_posts/2014-06-06-adding-bootstrap-to-ember-cli.md
@@ -5,7 +5,7 @@ tagline: ""
 tags : [ember, ember-cli]
 title: "Adding Bootstrap to Ember-CLI"
 description: Directions for adding bootstrap to Ember-CLI.
-author: Mike Munroe
+author: mike_munroe
 ---
 {% include JB/setup %}
 

--- a/_posts/2014-06-13-render-data-for-mulitple-models-in-a-view-in-Ember.md
+++ b/_posts/2014-06-13-render-data-for-mulitple-models-in-a-view-in-Ember.md
@@ -5,7 +5,7 @@ tagline: ""
 tags : [ember]
 title: "Render Data from Multiple Models in One View in Ember"
 description: Directions for showing data from multiple models inside of one view.
-author: Mike Munroe
+author: mike_munroe
 ---
 {% include JB/setup %}
 

--- a/_posts/2014-07-21-why-ember.md
+++ b/_posts/2014-07-21-why-ember.md
@@ -5,7 +5,7 @@ tagline: ""
 tags : [ember]
 title: "What is Ember.js?"
 description: What is the big deal about Ember.js?
-author: Mike Munroe
+author: mike_munroe
 ---
 {% include JB/setup %}
 

--- a/_posts/2014-08-04-source-control.md
+++ b/_posts/2014-08-04-source-control.md
@@ -5,7 +5,7 @@ tagline: ""
 tags : [founder]
 title: "Founder Series: The Code for Your Application"
 description: What is source control and why is it important?
-author: Mike Munroe
+author: mike_munroe
 ---
 {% include JB/setup %}
 

--- a/_posts/2014-08-29-front-back.md
+++ b/_posts/2014-08-29-front-back.md
@@ -5,7 +5,7 @@ tagline: ""
 tags : [founder]
 title: "Founder Series: What is the difference between front end and back end?"
 description: Developers often talk about front end code or back end code. What does that mean?
-author: Mike Munroe
+author: mike_munroe
 ---
 {% include JB/setup %}
 

--- a/_posts/2014-10-10-ember-browsers.md
+++ b/_posts/2014-10-10-ember-browsers.md
@@ -5,7 +5,7 @@ tagline: ""
 tags : [ember]
 title: "What browsers does Ember.js support?"
 description: Ember.js browser support
-author: Mike Munroe
+author: mike_munroe
 ---
 {% include JB/setup %}
 

--- a/_posts/2015-01-27-continuous-integration-with-rails-ember-cli-and-circleci.md
+++ b/_posts/2015-01-27-continuous-integration-with-rails-ember-cli-and-circleci.md
@@ -4,7 +4,7 @@ title: "Continuous Integration with Rails, Ember CLI, and CircleCI"
 description: "How to set up continuous integration for a Rails and Ember CLI application."
 category:
 tags: [rails, ember-cli, CircleCI, continuous-integration]
-author: Eric Kelly
+author: eric_kelly
 ---
 {% include JB/setup %}
 

--- a/home.html
+++ b/home.html
@@ -9,15 +9,17 @@ group: navigation
 
 <ul class="posts">
   {% for post in site.posts %}
-  <li>
-    <div class="post-title"><a href="{{ BASE_PATH }}{{ post.url }}">{{ post.title }}</a></div>
-    <div class="post-author">
-      <span>{{ post.author }}</span> &raquo;
-      <span>{{ post.date | date_to_string }}</span>
-    </div>
-    <div class="post-description">
-      {{ post.description }}
-    </div>
-  </li>
+    {% assign author = site.data.authors[post.author] %}
+
+    <li>
+      <div class="post-title"><a href="{{ BASE_PATH }}{{ post.url }}">{{ post.title }}</a></div>
+      <div class="post-author">
+        <span>{{ author.name }}</span> &raquo;
+        <span>{{ post.date | date_to_string }}</span>
+      </div>
+      <div class="post-description">
+        {{ post.description }}
+      </div>
+    </li>
   {% endfor %}
 </ul>

--- a/index.html
+++ b/index.html
@@ -9,15 +9,17 @@ group: navigation
 
 <ul class="posts">
   {% for post in site.posts %}
-  <li>
-    <div class="post-title"><a href="{{ BASE_PATH }}{{ post.url }}">{{ post.title }}</a></div>
-    <div class="post-author">
-      <span>{{ post.author }}</span> &raquo;
-      <span>{{ post.date | date_to_string }}</span>
-    </div>
-    <div class="post-description">
-      {{ post.description }}
-    </div>
-  </li>
+    {% assign author = site.data.authors[post.author] %}
+
+    <li>
+      <div class="post-title"><a href="{{ BASE_PATH }}{{ post.url }}">{{ post.title }}</a></div>
+      <div class="post-author">
+        <span>{{ author.name }}</span> &raquo;
+        <span>{{ post.date | date_to_string }}</span>
+      </div>
+      <div class="post-description">
+        {{ post.description }}
+      </div>
+    </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
Adds a link to author's twitter on the post page.

Looks like:

![screen shot 2015-01-28 at 12 58 48 pm](https://cloud.githubusercontent.com/assets/602204/5943539/d23ded82-a6ed-11e4-9a50-ee75d31178b3.png)

We can get more detailed with photos etc but this sets up all the plumbing for for now.
