### PR TITLE
SEC filing parser w/ Floki draft

### DIFF
--- a/_posts/2016-03-21-sec-filing-parser-floki.md
+++ b/_posts/2016-03-21-sec-filing-parser-floki.md
@@ -16,7 +16,7 @@ with the [Floki](https://github.com/philss/floki) HTML parser.
 At Greenfield, we've become more interested in FinTech after modernizing
 a large Financial Services client's web application. We've also been experimenting
 with [Elixir](http://elixir-lang.org/), which, we think, would make a great technological
-fit in FinTech given its speed and scalability.
+fit in FinTech for its speed and scalability benefits.
 
 Recently, we wanted to take a look at how Elixir could be used for parsing
 data. We investigated the [website](https://www.sec.gov) of the
@@ -265,8 +265,8 @@ end
 Here, we grab the entire feed, find all the entries in `parse_feed/1` and map
 them to generate the maps above so we end up with a list of maps.
 
-You'll notice `Floki.raw_html/1` which lets us select an entry and return the
-HTML of that entry. What `parse_feed/1` does here is the following:
+You'll notice the use of `Floki.raw_html/1` which lets us select an entry and 
+return the HTML of that entry. What `parse_feed/1` does here is the following:
 
 ```
 1. Find all elements with element name of "entry"

--- a/_posts/2016-03-21-sec-filing-parser-floki.md
+++ b/_posts/2016-03-21-sec-filing-parser-floki.md
@@ -83,8 +83,8 @@ libraries is [awesome-elixir](https://github.com/h4cc/awesome-elixir). I found
 some of the other libraries for the purposes here.
 
 Floki abstracts away a lot of selection headache associated with other parsers.
-It uses XML element names to grab precisely what you expect to grab. Say your XML feed
-entry (`entry_xml`) looks like this:
+It allows you to use XML element names to grab precisely what you expect to 
+grab. Say your XML feed entry (`entry_xml`) looks like this:
 
 ```xml
 <entry>
@@ -105,7 +105,7 @@ entry (`entry_xml`) looks like this:
 "497K - PNC FUNDS (0000778202)"
 ```
 
-Similarlly, calling `entry_xml |> Floki.find("updated")` returns the following:
+Similarly, `entry_xml |> Floki.find("updated")` returns the following:
 
 ```
 "2016-03-18T13:00:33-04:00"

--- a/_posts/2016-03-21-sec-filing-parser-floki.md
+++ b/_posts/2016-03-21-sec-filing-parser-floki.md
@@ -23,13 +23,11 @@ data. We investigated the [website](https://www.sec.gov) of the
 Securities and Exchange Commission or SEC, which is an agency of the US Government
 that handles and enforces various securities related laws. One duty of companies
 that are registered with the SEC is that they must provide regular public filings.
-Their website hosts a phenomenal amount of material.
+The SEC's website hosts a phenomenal amount of material.
 
-In particular, for those who are interested in public markets and the filings
-of companies they might invest in, it houses years of such filings.
 Unfortunately, much of this data is difficult to handle for a number of reasons,
-but primarily because of a lack of standardization across filings. However, they
-do host a convenient RSS Feed for the latest filings located [here](https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type=&company=&dateb=&owner=include&start=0&count=40&output=atom).
+but primarily because of a lack of standardization across filings. However, the
+SEC does host a convenient RSS Feed for the latest filings located [here](https://www.sec.gov/cgi-bin/browse-edgar?action=getcurrent&type=&company=&dateb=&owner=include&start=0&count=40&output=atom).
 The RSS Feed looks something like this:
 
 ```xml


### PR DESCRIPTION
This PR is a blog post for the Greenfield [blog](http://blog.greenfieldhq.com/). It highlights the `Floki` HTML parsing library and its use in parsing the SEC RSS Feed.
